### PR TITLE
Create responsive personal portfolio site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# portfolio2.0
+# Jordan Rivera · Portfolio
+
+A modern, responsive, and accessible personal portfolio website for a hybrid product designer and front-end engineer.
+
+## Features
+
+- Hero section with key stats and clear calls to action
+- Story-driven sections for about, skills, experience timeline, projects, writing, testimonials, and contact
+- Responsive layout with mobile navigation menu and adaptive typography
+- Light/dark theme toggle with preference persistence
+- Accessible markup including skip link, semantic structure, and focus states
+- Scroll-triggered reveal animations for visual polish
+
+## Getting started
+
+Open `index.html` in your browser to explore the site. No additional build steps are required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Personal portfolio for showcasing design systems, engineering projects, and writing." />
+    <title>Jordan Rivera — Product Designer & Engineer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="script.js"></script>
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+    <header class="site-header" id="top">
+      <div class="container">
+        <a class="logo" href="#top" aria-label="Jordan Rivera home">
+          <span class="logo__mark">JR</span>
+          <span class="logo__text">Jordan Rivera</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary">
+          <button class="nav-toggle" aria-expanded="false" aria-controls="site-menu">
+            <span class="sr-only">Toggle navigation</span>
+            <span class="nav-toggle__line"></span>
+            <span class="nav-toggle__line"></span>
+            <span class="nav-toggle__line"></span>
+          </button>
+          <ul id="site-menu" class="site-menu">
+            <li><a href="#about">About</a></li>
+            <li><a href="#skills">Skills</a></li>
+            <li><a href="#experience">Experience</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#writing">Writing</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+        <button class="theme-toggle" aria-label="Toggle theme">
+          <span aria-hidden="true">🌙</span>
+        </button>
+      </div>
+    </header>
+
+    <main id="main">
+      <section class="hero" aria-labelledby="hero-title">
+        <div class="container hero__content">
+          <div>
+            <p class="hero__eyebrow">Product Designer & Front-end Engineer</p>
+            <h1 id="hero-title">Designing delightful experiences grounded in systems thinking.</h1>
+            <p class="hero__description">
+              I blend human-centered design with robust engineering to craft scalable products that people love.
+              From zero-to-one MVPs to global design systems, I help teams ship with clarity and confidence.
+            </p>
+            <div class="hero__actions">
+              <a class="button button--primary" href="#projects">View projects</a>
+              <a class="button button--secondary" href="#contact">Let's collaborate</a>
+            </div>
+            <dl class="hero__stats">
+              <div>
+                <dt>10+</dt>
+                <dd>Years crafting digital products</dd>
+              </div>
+              <div>
+                <dt>24%</dt>
+                <dd>Increase in activation for latest redesign</dd>
+              </div>
+              <div>
+                <dt>5</dt>
+                <dd>Design systems launched across platforms</dd>
+              </div>
+            </dl>
+          </div>
+          <figure class="hero__portrait" aria-label="Portrait illustration">
+            <img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=600&q=80" alt="Portrait of Jordan Rivera" />
+            <figcaption>Currently shaping the future of collaboration at Cohere Labs.</figcaption>
+          </figure>
+        </div>
+      </section>
+
+      <section id="about" class="section" aria-labelledby="about-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">About</p>
+            <h2 id="about-title">Systems-minded designer who codes.</h2>
+          </div>
+          <div class="section__body grid-two">
+            <p>
+              I design for clarity, usability, and measurable impact. My process is rooted in research and rapid iteration,
+              aligning diverse teams around a shared product vision. I specialize in building design systems and front-end
+              architectures that scale effortlessly.
+            </p>
+            <p>
+              Beyond product work, I mentor emerging designers, write about craft, and speak at design events. When I'm not
+              prototyping, you can find me curating playlists or exploring cities by bike.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="skills" class="section section--alt" aria-labelledby="skills-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Capabilities</p>
+            <h2 id="skills-title">A blend of strategic insight and hands-on craft.</h2>
+          </div>
+          <div class="skills__grid">
+            <article class="card">
+              <h3>Product Strategy</h3>
+              <p>Discovery workshops, customer research synthesis, roadmap alignment, success metrics.</p>
+              <ul class="skill-tags">
+                <li>Design sprints</li>
+                <li>Product vision</li>
+                <li>Journey mapping</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Experience Design</h3>
+              <p>Interaction patterns, accessibility audits, prototyping, usability testing, copywriting.</p>
+              <ul class="skill-tags">
+                <li>Figma</li>
+                <li>Axure</li>
+                <li>Maze</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Design Systems</h3>
+              <p>Component libraries, tokens, documentation, governance, cross-functional enablement.</p>
+              <ul class="skill-tags">
+                <li>Design tokens</li>
+                <li>Storybook</li>
+                <li>Accessibility</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Front-end Engineering</h3>
+              <p>Semantic HTML, scalable CSS architecture, React, performance audits, CI/CD workflows.</p>
+              <ul class="skill-tags">
+                <li>TypeScript</li>
+                <li>Next.js</li>
+                <li>Design ops</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="experience" class="section" aria-labelledby="experience-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Experience</p>
+            <h2 id="experience-title">Career at a glance.</h2>
+          </div>
+          <ol class="timeline">
+            <li class="timeline__item">
+              <div class="timeline__marker"></div>
+              <div class="timeline__content">
+                <span class="timeline__date">2021 — Present</span>
+                <h3>Cohere Labs · Principal Product Designer</h3>
+                <p>
+                  Leading the creation of a unified collaboration suite serving 6M users. Established a design system that
+                  reduced design debt by 38% and accelerated shipping cadence by 2×.
+                </p>
+              </div>
+            </li>
+            <li class="timeline__item">
+              <div class="timeline__marker"></div>
+              <div class="timeline__content">
+                <span class="timeline__date">2017 — 2021</span>
+                <h3>Atlas Analytics · Staff Designer & Engineer</h3>
+                <p>
+                  Spearheaded cross-platform analytics tools and mentored a hybrid design-engineering team. Improved data
+                  comprehension scores by 26% through guided storytelling interfaces.
+                </p>
+              </div>
+            </li>
+            <li class="timeline__item">
+              <div class="timeline__marker"></div>
+              <div class="timeline__content">
+                <span class="timeline__date">2013 — 2017</span>
+                <h3>Freelance · Product Designer</h3>
+                <p>
+                  Collaborated with early-stage startups to launch MVPs and design systems, winning two Webby honors for
+                  craft in interaction design.
+                </p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </section>
+
+      <section id="projects" class="section section--alt" aria-labelledby="projects-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Selected Work</p>
+            <h2 id="projects-title">Projects that moved metrics.</h2>
+          </div>
+          <div class="projects__grid">
+            <article class="project-card">
+              <img src="https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=600&q=80" alt="Dashboard interface with charts" />
+              <div class="project-card__content">
+                <h3>Unified Collaboration Suite</h3>
+                <p>
+                  Modernized workplace collaboration with shared canvases, video-first workflows, and real-time AI insights,
+                  resulting in 41% higher team adoption.
+                </p>
+                <a class="project-card__link" href="#">Read case study</a>
+              </div>
+            </article>
+            <article class="project-card">
+              <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=600&q=80" alt="Mobile interface showing data visualizations" />
+              <div class="project-card__content">
+                <h3>Insights on the Go</h3>
+                <p>
+                  Architected a responsive analytics experience optimized for mobile, increasing executive engagement by 3×
+                  and cutting reporting time in half.
+                </p>
+                <a class="project-card__link" href="#">Read case study</a>
+              </div>
+            </article>
+            <article class="project-card">
+              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=600&q=80" alt="Team collaborating around sticky notes" />
+              <div class="project-card__content">
+                <h3>Design Ops Evolution</h3>
+                <p>
+                  Built a scalable design ops program with rituals, tooling, and measurement that doubled satisfaction scores
+                  across design and engineering.
+                </p>
+                <a class="project-card__link" href="#">Read case study</a>
+              </div>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="writing" class="section" aria-labelledby="writing-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Writing</p>
+            <h2 id="writing-title">Sharing lessons from the field.</h2>
+          </div>
+          <div class="writing__list">
+            <article class="writing__item">
+              <p class="writing__date">May 2024</p>
+              <h3><a href="#">Design Systems as Cultural Bridges</a></h3>
+              <p>How to align distributed teams through shared patterns, governance, and measurement frameworks.</p>
+            </article>
+            <article class="writing__item">
+              <p class="writing__date">Feb 2024</p>
+              <h3><a href="#">Measuring the ROI of Research</a></h3>
+              <p>Turning qualitative insights into product direction and stakeholder conviction.</p>
+            </article>
+            <article class="writing__item">
+              <p class="writing__date">Nov 2023</p>
+              <h3><a href="#">Accessibility as a Product Superpower</a></h3>
+              <p>Embedding inclusive practices in design systems to deliver better experiences for everyone.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="testimonials" class="section section--alt" aria-labelledby="testimonials-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Testimonials</p>
+            <h2 id="testimonials-title">Partners and peers on working together.</h2>
+          </div>
+          <div class="testimonial__grid">
+            <figure class="testimonial">
+              <blockquote>
+                “Jordan brings a rare combination of product vision, craft, and the ability to rally teams around a shared
+                goal. We shipped our most ambitious release on schedule because of their leadership.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial__name">Avery Chen</span>
+                <span class="testimonial__role">VP of Product, Cohere Labs</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial">
+              <blockquote>
+                “They understand the nuances of design systems and how to evolve them sustainably. Our velocity and quality
+                improved dramatically.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial__name">Mateo Ruiz</span>
+                <span class="testimonial__role">Director of Engineering, Atlas Analytics</span>
+              </figcaption>
+            </figure>
+            <figure class="testimonial">
+              <blockquote>
+                “Jordan mentors with clarity and empathy. Their guidance elevated our craft and confidence across the design
+                org.”
+              </blockquote>
+              <figcaption>
+                <span class="testimonial__name">Priya Kapoor</span>
+                <span class="testimonial__role">Lead Designer, Mosaic</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section contact" aria-labelledby="contact-title">
+        <div class="container section__content">
+          <div class="section__header">
+            <p class="section__eyebrow">Get in touch</p>
+            <h2 id="contact-title">Let's build something meaningful.</h2>
+          </div>
+          <div class="contact__grid">
+            <div>
+              <p>
+                Whether you're shaping a new product or evolving a mature platform, I'm here to help. Share a bit about your
+                challenge and I'll respond within two business days.
+              </p>
+              <ul class="contact__details">
+                <li><strong>Email:</strong> <a href="mailto:hello@jordanrivera.design">hello@jordanrivera.design</a></li>
+                <li><strong>Location:</strong> Portland, OR · Remote friendly</li>
+                <li><strong>Availability:</strong> Accepting new collaborations from July 2024</li>
+              </ul>
+            </div>
+            <form class="contact__form" aria-label="Contact form">
+              <label for="name">Name</label>
+              <input id="name" name="name" type="text" required />
+
+              <label for="email">Email</label>
+              <input id="email" name="email" type="email" required />
+
+              <label for="company">Company</label>
+              <input id="company" name="company" type="text" />
+
+              <label for="message">Project details</label>
+              <textarea id="message" name="message" rows="4" required></textarea>
+
+              <button type="submit" class="button button--primary">Send message</button>
+              <p class="contact__note">I'll never share your information. Required fields are marked.</p>
+            </form>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container site-footer__content">
+        <div>
+          <p class="site-footer__title">Jordan Rivera</p>
+          <p>Crafting considered products that balance user needs and business outcomes.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="#about">About</a>
+          <a href="#projects">Projects</a>
+          <a href="#writing">Writing</a>
+          <a href="#contact">Contact</a>
+        </div>
+        <div class="site-footer__meta">
+          <p>© <span id="current-year"></span> Jordan Rivera. All rights reserved.</p>
+          <a href="#top" class="site-footer__top">Back to top</a>
+        </div>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,61 @@
+const navToggle = document.querySelector('.nav-toggle');
+const siteMenu = document.getElementById('site-menu');
+const themeToggle = document.querySelector('.theme-toggle');
+const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)');
+const storedTheme = localStorage.getItem('theme');
+
+const setTheme = (mode) => {
+  document.body.classList.toggle('dark', mode === 'dark');
+  localStorage.setItem('theme', mode);
+  themeToggle.querySelector('span').textContent = mode === 'dark' ? '☀️' : '🌙';
+};
+
+if (storedTheme) {
+  setTheme(storedTheme);
+} else if (prefersDarkScheme.matches) {
+  setTheme('dark');
+}
+
+themeToggle.addEventListener('click', () => {
+  const isDark = document.body.classList.toggle('dark');
+  const mode = isDark ? 'dark' : 'light';
+  localStorage.setItem('theme', mode);
+  themeToggle.querySelector('span').textContent = isDark ? '☀️' : '🌙';
+});
+
+if (navToggle) {
+  navToggle.addEventListener('click', () => {
+    const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!expanded));
+    siteMenu.setAttribute('aria-expanded', String(!expanded));
+  });
+
+  siteMenu.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      navToggle.setAttribute('aria-expanded', 'false');
+      siteMenu.setAttribute('aria-expanded', 'false');
+    });
+  });
+}
+
+const observer = new IntersectionObserver(
+  (entries) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('is-visible');
+        observer.unobserve(entry.target);
+      }
+    });
+  },
+  { threshold: 0.15 }
+);
+
+document.querySelectorAll('.section, .project-card, .testimonial').forEach((element) => {
+  element.classList.add('will-animate');
+  observer.observe(element);
+});
+
+const yearEl = document.getElementById('current-year');
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,662 @@
+:root {
+  color-scheme: light dark;
+  --font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-display: 'Playfair Display', Georgia, serif;
+  --color-bg: #f8f9fb;
+  --color-surface: #ffffff;
+  --color-muted: #6b7280;
+  --color-text: #0f172a;
+  --color-primary: #4f46e5;
+  --color-secondary: #f97316;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --shadow-soft: 0 20px 45px rgba(15, 23, 42, 0.08);
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+}
+
+body.dark {
+  --color-bg: #0f172a;
+  --color-surface: #111c34;
+  --color-muted: #94a3b8;
+  --color-text: #e2e8f0;
+  --color-primary: #6366f1;
+  --color-border: rgba(226, 232, 240, 0.12);
+  --shadow-soft: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+  font-size: 1rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-primary);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-primary);
+  color: white;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  transition: top 0.3s ease;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  top: 16px;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(16px);
+  background: color-mix(in srgb, var(--color-bg) 80%, transparent);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem 0;
+}
+
+.logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.logo__mark {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  color: white;
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-menu {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-menu a {
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-muted);
+  position: relative;
+  padding: 0.5rem 0;
+}
+
+.site-menu a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: center;
+  transition: transform 0.3s ease;
+}
+
+.site-menu a:hover::after,
+.site-menu a:focus::after {
+  transform: scaleX(1);
+}
+
+.theme-toggle {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-muted);
+  border-radius: 999px;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus {
+  transform: translateY(-1px);
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  padding: 0.5rem;
+}
+
+.nav-toggle__line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  background: var(--color-text);
+  margin: 4px 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hero {
+  padding: 8rem 0 6rem;
+}
+
+.hero__content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero__eyebrow {
+  color: var(--color-secondary);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.hero__description {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  max-width: 520px;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 1.75rem 0 2.5rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: white;
+}
+
+.button--secondary {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.5rem;
+  margin: 3rem 0 0;
+}
+
+.hero__stats dt {
+  font-size: 2.5rem;
+  font-weight: 700;
+}
+
+.hero__stats dd {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.hero__portrait {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.hero__portrait img {
+  aspect-ratio: 4 / 5;
+  object-fit: cover;
+}
+
+.hero__portrait figcaption {
+  padding: 1.5rem;
+  color: var(--color-muted);
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+.section--alt {
+  background: color-mix(in srgb, var(--color-surface) 60%, var(--color-bg));
+}
+
+.section__header {
+  max-width: 620px;
+  margin-bottom: 2.5rem;
+}
+
+.section__eyebrow {
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+}
+
+.section__body {
+  color: var(--color-muted);
+  font-size: 1.05rem;
+}
+
+.grid-two {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.skills__grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.card p {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.skill-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.skill-tags li {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-primary) 18%, var(--color-surface));
+  color: var(--color-primary);
+  font-weight: 500;
+  font-size: 0.85rem;
+}
+
+.timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-left: 2px solid var(--color-border);
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: -10px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(var(--color-primary), transparent);
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 2rem;
+  margin-bottom: 2.75rem;
+}
+
+.timeline__item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline__marker {
+  position: absolute;
+  left: -18px;
+  top: 0.4rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--color-primary);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--color-primary) 20%, transparent);
+}
+
+.timeline__date {
+  font-weight: 600;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.projects__grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.project-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.project-card img {
+  aspect-ratio: 16 / 10;
+  object-fit: cover;
+}
+
+.project-card__content {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.project-card__link {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.writing__list {
+  display: grid;
+  gap: 2rem;
+}
+
+.writing__item {
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.3s ease;
+}
+
+.writing__item:hover,
+.writing__item:focus-within {
+  transform: translateY(-4px);
+}
+
+.writing__date {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-secondary);
+  margin-bottom: 0.75rem;
+}
+
+.testimonial__grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.testimonial {
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.testimonial blockquote {
+  margin: 0;
+  font-size: 1.05rem;
+  font-style: italic;
+  color: var(--color-muted);
+}
+
+.testimonial__name {
+  font-weight: 600;
+}
+
+.testimonial__role {
+  display: block;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.contact__grid {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  align-items: start;
+}
+
+.contact__details {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.contact__form {
+  display: grid;
+  gap: 1rem;
+  background: var(--color-surface);
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact__form label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.contact__form input,
+.contact__form textarea {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 75%, var(--color-bg));
+  color: var(--color-text);
+  font: inherit;
+}
+
+.contact__form input:focus,
+.contact__form textarea:focus {
+  outline: 2px solid color-mix(in srgb, var(--color-primary) 60%, transparent);
+  border-color: var(--color-primary);
+}
+
+.contact__note {
+  color: var(--color-muted);
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.site-footer {
+  padding: 3rem 0;
+  border-top: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 70%, var(--color-bg));
+}
+
+.site-footer__content {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.site-footer__title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.site-footer__links {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.site-footer__meta {
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.site-footer__top {
+  justify-self: start;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .site-header .container {
+    padding: 0.75rem 0;
+  }
+
+  .nav-toggle {
+    display: block;
+  }
+
+  .site-menu {
+    position: absolute;
+    right: 1rem;
+    top: 100%;
+    flex-direction: column;
+    align-items: flex-start;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 1rem 1.5rem;
+    box-shadow: var(--shadow-soft);
+    transform: translateY(1rem);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+  }
+
+  .site-menu[aria-expanded='true'] {
+    transform: translateY(0.5rem);
+    opacity: 1;
+    pointer-events: all;
+  }
+
+  .theme-toggle {
+    order: 3;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.will-animate {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}


### PR DESCRIPTION
## Summary
- add semantic single-page portfolio layout with hero, about, skills, experience, projects, writing, testimonials, and contact sections
- implement modern styling with responsive grid layouts, accessible states, and light/dark theming support
- enhance interactivity with persisted theme toggle, mobile navigation controls, and scroll-triggered reveal animations

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d616b925e0832ba443cc3e55d209cc